### PR TITLE
Update helm to pull image from the attached GCP project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 descriptors/
+.idea/

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ helm-%:
 	helm upgrade -i $* -n $* manifests/$* \
 		--set image.tag=$(TAG) \
 		--set image.repo=gcr.io/$(GCP_PROJECT)/$* \
+		--set gcp_project=${GCP_PROJECT} \
 		--create-namespace
 
 protos: $(PROTO_OUTS)

--- a/manifests/bookstorehttpserver/templates/deployment.yaml
+++ b/manifests/bookstorehttpserver/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "gcr.io/{{ .Values.gcp_project }}/bookstorehttpserver:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/manifests/bookstorehttpserver/values.yaml
+++ b/manifests/bookstorehttpserver/values.yaml
@@ -5,7 +5,6 @@
 replicaCount: 1
 
 image:
-  repository: gcr.io/yangguan-gke-dev/bookstorehttpserver
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/manifests/bookstoreserver/templates/deployment.yaml
+++ b/manifests/bookstoreserver/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "gcr.io/{{ .Values.gcp_project }}/bookstoreserver:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: grpc

--- a/manifests/bookstoreserver/values.yaml
+++ b/manifests/bookstoreserver/values.yaml
@@ -5,7 +5,6 @@
 replicaCount: 1
 
 image:
-  repository: gcr.io/yangguan-gke-dev/bookstoreserver
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/manifests/extprocserver/templates/deployment.yaml
+++ b/manifests/extprocserver/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "gcr.io/{{ .Values.gcp_project }}/extprocserver:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: grpc

--- a/manifests/extprocserver/values.yaml
+++ b/manifests/extprocserver/values.yaml
@@ -5,7 +5,6 @@
 replicaCount: 1
 
 image:
-  repository: "gcr.io/yangguan-gke-dev/extprocserver"
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"

--- a/manifests/httpserver/templates/deployment.yaml
+++ b/manifests/httpserver/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- $chartVersion  := .Chart.AppVersion -}}
-{{- $repo  := .Values.image.repository -}}
+{{- $gcp_project  := .Values.gcp_project  -}}
 {{- $tag  := .Values.image.tag -}}
 {{- range $index, $version := .Values.versions }}
 apiVersion: apps/v1
@@ -21,7 +21,7 @@ spec:
     spec:
       serviceAccountName: httpserver
       containers:
-      - image: "{{ $repo }}:{{ $tag | default $chartVersion }}"
+      - image: "gcr.io/{{ $gcp_project }}/httpserver:{{ $tag | default $chartVersion }}"
         imagePullPolicy: IfNotPresent
         name: httpserver
         command:

--- a/manifests/httpserver/values.yaml
+++ b/manifests/httpserver/values.yaml
@@ -5,7 +5,6 @@
 replicaCount: 1
 
 image:
-  repository: "gcr.io/yangguan-gke-dev/httpserver"
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"


### PR DESCRIPTION
Currently the script statically uses `yangguan-gke-dev` to download target images and after this PR the attached GCP project will be used.